### PR TITLE
Bug fix for subtraction operator being mistaken for sign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,11 +1313,11 @@ name = "raekna"
 version = "0.1.1"
 dependencies = [
  "criterion",
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "raekna-compute 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "raekna-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "raekna-storage 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "raekna-ui 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raekna-common",
+ "raekna-compute",
+ "raekna-parser",
+ "raekna-storage",
+ "raekna-ui",
 ]
 
 [[package]]
@@ -1325,25 +1325,10 @@ name = "raekna-common"
 version = "0.1.1"
 
 [[package]]
-name = "raekna-common"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ceeb1fa771f5460b93bc4b8aa4c40e6c09991ab303858dc08ee9b4d8792277"
-
-[[package]]
 name = "raekna-compute"
 version = "0.1.1"
 dependencies = [
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "raekna-compute"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f016711004d5c26888cf7734846ddeae4cb16ef11d9cdba7e991b664dd2e66e9"
-dependencies = [
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raekna-common",
 ]
 
 [[package]]
@@ -1351,33 +1336,14 @@ name = "raekna-parser"
 version = "0.1.1"
 dependencies = [
  "nom",
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "raekna-parser"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe429dfb02e5ec19ed41514bc50160fa69e61fec4d9c82bccc12c8dec8038ef8"
-dependencies = [
- "nom",
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raekna-common",
 ]
 
 [[package]]
 name = "raekna-storage"
 version = "0.1.1"
 dependencies = [
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "raekna-storage"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466d6bb714de91c3ce9799b1b5783e7e34766590552dfdb9e55e6eaca602495e"
-dependencies = [
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raekna-common",
 ]
 
 [[package]]
@@ -1389,24 +1355,7 @@ dependencies = [
  "env_logger",
  "futures-lite",
  "log",
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu",
- "wgpu_glyph",
- "winit",
-]
-
-[[package]]
-name = "raekna-ui"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a03a81ec0fa43c0e7a2e072c7175c74991903dfffc7757899a9fefb895978c"
-dependencies = [
- "bytemuck",
- "copypasta",
- "env_logger",
- "futures-lite",
- "log",
- "raekna-common 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raekna-common",
  "wgpu",
  "wgpu_glyph",
  "winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ resolver = "2"
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much.
 debug = 0
+
+[patch.crates-io]
+raekna-common = { path = "raekna-common" }
+raekna-compute = { path = "raekna-compute" }
+raekna-parser = { path = "raekna-parser" }
+raekna-storage = { path = "raekna-storage" }
+raekna-ui = { path = "raekna-ui" }

--- a/raekna-common/src/function_name.rs
+++ b/raekna-common/src/function_name.rs
@@ -4,8 +4,11 @@ use crate::errors::{CommonError, CommonResult};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FunctionName {
+    // Unary
     SquareRoot,
     Factorial,
+    Negate,
+    // Binary
     Max,
     Min,
     Add,
@@ -19,7 +22,7 @@ pub enum FunctionName {
 impl FunctionName {
     pub fn num_arguments(&self) -> usize {
         match self {
-            FunctionName::SquareRoot | FunctionName::Factorial => 1,
+            FunctionName::SquareRoot | FunctionName::Factorial | FunctionName::Negate => 1,
             FunctionName::Max
             | FunctionName::Min
             | FunctionName::Add
@@ -39,6 +42,7 @@ impl FromStr for FunctionName {
         match arg.to_lowercase().as_str() {
             "sqrt" | "squareroot" | "square_root" => Ok(Self::SquareRoot),
             "fact" | "factorial" => Ok(Self::Factorial),
+            "neg" | "negate" => Ok(Self::Negate),
             "min" | "minimum" => Ok(Self::Min),
             "max" | "maximum" => Ok(Self::Max),
             "add" => Ok(Self::Add),
@@ -57,6 +61,7 @@ impl fmt::Display for FunctionName {
         match self {
             FunctionName::SquareRoot => write!(fmt, "sqrt"),
             FunctionName::Factorial => write!(fmt, "factorial"),
+            FunctionName::Negate => write!(fmt, "negate"),
             FunctionName::Max => write!(fmt, "max"),
             FunctionName::Min => write!(fmt, "min"),
             FunctionName::Add => write!(fmt, "add"),

--- a/raekna-compute/src/ops/arithmetic.rs
+++ b/raekna-compute/src/ops/arithmetic.rs
@@ -35,8 +35,8 @@ pub fn factorial(value: Literal) -> ComputeResult<Literal> {
 
 pub fn negate(value: Literal) -> ComputeResult<Literal> {
     let res = match value {
-        Literal::Integer(i) => Literal::Integer(i * -1),
-        Literal::Float(f) => Literal::Float(f * -1.0),
+        Literal::Integer(i) => Literal::Integer(-i),
+        Literal::Float(f) => Literal::Float(-f),
     };
     Ok(res)
 }

--- a/raekna-compute/src/ops/arithmetic.rs
+++ b/raekna-compute/src/ops/arithmetic.rs
@@ -33,6 +33,14 @@ pub fn factorial(value: Literal) -> ComputeResult<Literal> {
     }
 }
 
+pub fn negate(value: Literal) -> ComputeResult<Literal> {
+    let res = match value {
+        Literal::Integer(i) => Literal::Integer(i * -1),
+        Literal::Float(f) => Literal::Float(f * -1.0),
+    };
+    Ok(res)
+}
+
 pub fn add(left: Literal, right: Literal) -> Literal {
     use Literal::*;
     let sum = match (left, right) {

--- a/raekna-compute/src/ops/mod.rs
+++ b/raekna-compute/src/ops/mod.rs
@@ -17,6 +17,7 @@ pub fn evaluate_fn(fn_name: FunctionName, args: Vec<Literal>) -> ComputeResult<L
         // Arithmetic
         FunctionName::SquareRoot => arithmetic::sqrt(args[0]),
         FunctionName::Factorial => arithmetic::factorial(args[0]),
+        FunctionName::Negate => arithmetic::negate(args[0]),
         FunctionName::Add => Ok(arithmetic::add(args[0], args[1])),
         FunctionName::Subtract => Ok(arithmetic::sub(args[0], args[1])),
         FunctionName::Multiply => Ok(arithmetic::mul(args[0], args[1])),

--- a/raekna-parser/src/errors.rs
+++ b/raekna-parser/src/errors.rs
@@ -12,6 +12,7 @@ pub enum ParserError {
         expressions: Vec<Option<Expression>>,
         operators: Vec<Operator>,
     },
+    InvalidSign(char),
     UnknownFunctionName(String),
     InvalidVariableDefinition(String),
     NomError(nom::Err<Error<()>>),

--- a/raekna-parser/src/parser.rs
+++ b/raekna-parser/src/parser.rs
@@ -116,16 +116,16 @@ impl Parser {
             }
         }
         match (self.expressions.is_empty(), self.operators.is_empty()) {
-            (true, true) => return Err(ParserError::EmptyExpression),
+            (true, true) => Err(ParserError::EmptyExpression),
             (true, false) => {
                 let mut expressions = vec![];
                 let mut operators = vec![];
                 std::mem::swap(&mut expressions, &mut self.expressions);
                 std::mem::swap(&mut operators, &mut self.operators);
-                return Err(ParserError::InvalidExpression {
+                Err(ParserError::InvalidExpression {
                     expressions,
                     operators,
-                });
+                })
             }
             _ => Ok(()),
         }

--- a/raekna-parser/src/parser.rs
+++ b/raekna-parser/src/parser.rs
@@ -21,129 +21,197 @@ pub fn parse(raw_expr: &'_ str) -> ParserResult<Expression> {
 }
 
 fn convert_token_tree(token_tree: TokenTree, allow_variable_def: bool) -> ParserResult<Expression> {
-    let mut variable = None;
-    let mut operators = Vec::with_capacity(token_tree.num_operators);
-    let mut expressions = vec![];
-
-    for (i, token) in token_tree.tokens.into_iter().enumerate() {
-        let expr = match token {
-            Token::Literal(literal) => {
-                let sn = match literal {
-                    Literal::Integer(i) => LiteralExpr::Integer(i),
-                    Literal::Float(f) => LiteralExpr::Float(f),
-                };
-                Some(Expression::Literal(sn))
-            }
-            Token::Operator(operator) => {
-                operators.push(operator);
-                None
-            }
-            Token::Function(name, args) => {
-                let args = args
-                    .into_iter()
-                    .map(|a| convert_token_tree(a, false))
-                    .collect::<ParserResult<Vec<_>>>()?;
-                let expr = Expression::Function(
-                    FunctionName::from_str(&name)
-                        .map_err(|_| ParserError::UnknownFunctionName(name))?,
-                    args,
-                );
-                Some(expr)
-            }
-            Token::VariableDefinition(name) => {
-                if i != 0 || !allow_variable_def {
-                    return Err(ParserError::InvalidVariableDefinition(name));
-                }
-                variable = Some(name);
-                None
-            }
-            Token::VariableReference(name) => Some(Expression::VariableRef(name)),
-            Token::Nested(nested_tree) => Some(convert_token_tree(nested_tree, false)?),
-        };
-        if let Some(expr) = expr {
-            expressions.push(Some(expr));
-        }
-    }
-    match (expressions.is_empty(), operators.is_empty()) {
-        (true, true) => return Err(ParserError::EmptyExpression),
-        (true, false) => {
-            return Err(ParserError::InvalidExpression {
-                expressions,
-                operators,
-            })
-        }
-        _ => {}
-    }
-    let expr = collapse_expressions(&mut expressions, &mut operators)?;
-    if let Some(name) = variable {
-        Ok(Expression::Variable(name, Box::new(expr)))
-    } else {
-        Ok(expr)
-    }
+    let mut parser = Parser::new(token_tree.num_operators);
+    parser.convert_token_tree(token_tree, allow_variable_def)?;
+    parser.finish()
 }
 
-fn collapse_expressions(
-    exprs: &mut [Option<Expression>],
-    operators: &mut [Operator],
-) -> ParserResult<Expression> {
-    if exprs.len() != operators.len() + 1 {
-        return Err(ParserError::InvalidExpression {
-            expressions: exprs.to_owned(),
-            operators: operators.to_owned(),
-        });
+struct Parser {
+    variable: Option<String>,
+    operators: Vec<Operator>,
+    expressions: Vec<Option<Expression>>,
+    is_sign: bool,
+    should_negate: bool,
+}
+
+impl Parser {
+    fn new(num_operators: usize) -> Self {
+        Self {
+            variable: None,
+            operators: Vec::with_capacity(num_operators),
+            expressions: vec![],
+            is_sign: false,
+            should_negate: false,
+        }
     }
-    if exprs.len() == 1 {
-        let mut res = None;
-        std::mem::swap(&mut exprs[0], &mut res);
-        Ok(res.unwrap())
-    } else {
-        let mut last_operator = (0, operators[0]);
-        for (i, o) in operators.iter().enumerate().skip(1) {
-            match (last_operator.1, o) {
-                (Operator::Power, _)
-                | (
-                    Operator::Multiply | Operator::Divide | Operator::Modulo,
-                    Operator::Multiply
-                    | Operator::Divide
-                    | Operator::Modulo
-                    | Operator::Add
-                    | Operator::Subtract,
-                )
-                | (Operator::Add | Operator::Subtract, Operator::Add | Operator::Subtract) => {
-                    last_operator = (i, *o)
+
+    fn finish(mut self) -> ParserResult<Expression> {
+        Self::collapse_expressions(&mut self.expressions, &mut self.operators, &self.variable)
+    }
+
+    fn convert_token_tree(
+        &mut self,
+        token_tree: TokenTree,
+        allow_variable_def: bool,
+    ) -> ParserResult<()> {
+        for (i, token) in token_tree.tokens.into_iter().enumerate() {
+            let expr = match token {
+                Token::Literal(literal) => {
+                    let sn = match literal {
+                        Literal::Integer(i) => {
+                            LiteralExpr::Integer(i * if self.should_negate { -1 } else { 1 })
+                        }
+                        Literal::Float(f) => {
+                            LiteralExpr::Float(f * if self.should_negate { -1.0 } else { 1.0 })
+                        }
+                    };
+                    self.is_sign = false;
+                    self.should_negate = false;
+                    Some(Expression::Literal(sn))
                 }
-                _ => {}
+                Token::Operator(operator) => {
+                    if self.is_sign {
+                        match operator {
+                            Operator::Add => {}
+                            Operator::Subtract => self.should_negate = true,
+                            Operator::Multiply => return Err(ParserError::InvalidSign('*')),
+                            Operator::Divide => return Err(ParserError::InvalidSign('/')),
+                            Operator::Modulo => return Err(ParserError::InvalidSign('%')),
+                            Operator::Power => return Err(ParserError::InvalidSign('^')),
+                        }
+                        self.is_sign = false;
+                    } else {
+                        self.operators.push(operator);
+                        self.is_sign = true;
+                    }
+                    None
+                }
+                Token::Function(name, args) => {
+                    let args = args
+                        .into_iter()
+                        .map(|a| convert_token_tree(a, false))
+                        .collect::<ParserResult<Vec<_>>>()?;
+                    let expr = Expression::Function(
+                        FunctionName::from_str(&name)
+                            .map_err(|_| ParserError::UnknownFunctionName(name))?,
+                        args,
+                    );
+                    let expr = self.maybe_negate(expr);
+                    self.is_sign = false;
+                    self.should_negate = false;
+                    Some(expr)
+                }
+                Token::VariableDefinition(name) => {
+                    if i != 0 || !allow_variable_def {
+                        return Err(ParserError::InvalidVariableDefinition(name));
+                    }
+                    self.variable = Some(name);
+                    None
+                }
+                Token::VariableReference(name) => Some(Expression::VariableRef(name)),
+                Token::Nested(nested_tree) => Some(convert_token_tree(nested_tree, false)?),
+            };
+            if let Some(expr) = expr {
+                self.expressions.push(Some(expr));
             }
         }
-        let left = if last_operator.0 == 0 {
-            let mut left = None;
-            std::mem::swap(&mut exprs[0], &mut left);
-            left.unwrap()
+        match (self.expressions.is_empty(), self.operators.is_empty()) {
+            (true, true) => return Err(ParserError::EmptyExpression),
+            (true, false) => {
+                let mut expressions = vec![];
+                let mut operators = vec![];
+                std::mem::swap(&mut expressions, &mut self.expressions);
+                std::mem::swap(&mut operators, &mut self.operators);
+                return Err(ParserError::InvalidExpression {
+                    expressions,
+                    operators,
+                });
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn collapse_expressions(
+        exprs: &mut [Option<Expression>],
+        operators: &mut [Operator],
+        variable: &Option<String>,
+    ) -> ParserResult<Expression> {
+        let expr = if exprs.len() != operators.len() + 1 {
+            return Err(ParserError::InvalidExpression {
+                expressions: exprs.to_owned(),
+                operators: operators.to_owned(),
+            });
+        } else if exprs.len() == 1 {
+            let mut res = None;
+            std::mem::swap(&mut exprs[0], &mut res);
+            res.unwrap()
         } else {
-            collapse_expressions(
-                &mut exprs[..last_operator.0 + 1],
-                &mut operators[..last_operator.0],
-            )?
+            let mut last_operator = (0, operators[0]);
+            for (i, o) in operators.iter().enumerate().skip(1) {
+                match (last_operator.1, o) {
+                    (Operator::Power, _)
+                    | (
+                        Operator::Multiply | Operator::Divide | Operator::Modulo,
+                        Operator::Multiply
+                        | Operator::Divide
+                        | Operator::Modulo
+                        | Operator::Add
+                        | Operator::Subtract,
+                    )
+                    | (Operator::Add | Operator::Subtract, Operator::Add | Operator::Subtract) => {
+                        last_operator = (i, *o)
+                    }
+                    _ => {}
+                }
+            }
+            let left = if last_operator.0 == 0 {
+                let mut left = None;
+                std::mem::swap(&mut exprs[0], &mut left);
+                left.unwrap()
+            } else {
+                Self::collapse_expressions(
+                    &mut exprs[..last_operator.0 + 1],
+                    &mut operators[..last_operator.0],
+                    variable,
+                )?
+            };
+            let right = if last_operator.0 == operators.len().saturating_sub(1) {
+                let mut left = None;
+                std::mem::swap(&mut exprs[operators.len()], &mut left);
+                left.unwrap()
+            } else {
+                Self::collapse_expressions(
+                    &mut exprs[last_operator.0 + 1..],
+                    &mut operators[last_operator.0 + 1..],
+                    variable,
+                )?
+            };
+            let function_name = match last_operator.1 {
+                Operator::Add => FunctionName::Add,
+                Operator::Subtract => FunctionName::Subtract,
+                Operator::Multiply => FunctionName::Multiply,
+                Operator::Divide => FunctionName::Divide,
+                Operator::Modulo => FunctionName::Modulus,
+                Operator::Power => FunctionName::Power,
+            };
+            Expression::Function(function_name, vec![left, right])
         };
-        let right = if last_operator.0 == operators.len().saturating_sub(1) {
-            let mut left = None;
-            std::mem::swap(&mut exprs[operators.len()], &mut left);
-            left.unwrap()
+        if let Some(name) = variable {
+            Ok(Expression::Variable(name.clone(), Box::new(expr)))
         } else {
-            collapse_expressions(
-                &mut exprs[last_operator.0 + 1..],
-                &mut operators[last_operator.0 + 1..],
-            )?
+            Ok(expr)
+        }
+    }
+
+    fn maybe_negate(&mut self, expr: Expression) -> Expression {
+        let expr = if self.should_negate {
+            Expression::Function(FunctionName::Negate, vec![expr])
+        } else {
+            expr
         };
-        let function_name = match last_operator.1 {
-            Operator::Add => FunctionName::Add,
-            Operator::Subtract => FunctionName::Subtract,
-            Operator::Multiply => FunctionName::Multiply,
-            Operator::Divide => FunctionName::Divide,
-            Operator::Modulo => FunctionName::Modulus,
-            Operator::Power => FunctionName::Power,
-        };
-        Ok(Expression::Function(function_name, vec![left, right]))
+        self.is_sign = false;
+        self.should_negate = false;
+        expr
     }
 }
 

--- a/raekna-parser/tests/integration_tests.rs
+++ b/raekna-parser/tests/integration_tests.rs
@@ -48,16 +48,6 @@ mod parse_literals {
 
             assert_eq!(actual, expected);
         }
-
-        #[test]
-        fn negative() {
-            let input = "-1234";
-
-            let expected = int(-1234);
-            let actual = parse(input);
-
-            assert_eq!(actual, expected);
-        }
     }
 
     mod decimals {
@@ -68,16 +58,6 @@ mod parse_literals {
             let input = "11.1";
 
             let expected = float(11.1);
-            let actual = parse(input);
-
-            assert_eq!(actual, expected);
-        }
-
-        #[test]
-        fn negative() {
-            let input = "-98.765";
-
-            let expected = float(-98.765);
             let actual = parse(input);
 
             assert_eq!(actual, expected);
@@ -108,26 +88,6 @@ mod parse_literals {
 
                     assert_eq!(actual, expected);
                 }
-
-                #[test]
-                fn neg_e_pos() {
-                    let input = "-6e5";
-
-                    let expected = int(-600000);
-                    let actual = parse(input);
-
-                    assert_eq!(actual, expected);
-                }
-
-                #[test]
-                fn neg_e_neg() {
-                    let input = "-2e-2";
-
-                    let expected = float(-0.02);
-                    let actual = parse(input);
-
-                    assert_eq!(actual, expected);
-                }
             }
 
             mod decimal_factor {
@@ -148,26 +108,6 @@ mod parse_literals {
                     let input = "7.987123e-3";
 
                     let expected = float(0.007987123);
-                    let actual = parse(input);
-
-                    assert_eq!(actual, expected);
-                }
-
-                #[test]
-                fn neg_e_pos() {
-                    let input = "-2.95e3";
-
-                    let expected = int(-2950);
-                    let actual = parse(input);
-
-                    assert_eq!(actual, expected);
-                }
-
-                #[test]
-                fn neg_e_neg() {
-                    let input = "-123.456e-3";
-
-                    let expected = float(-0.123456);
                     let actual = parse(input);
 
                     assert_eq!(actual, expected);

--- a/raekna-parser/tests/integration_tests.rs
+++ b/raekna-parser/tests/integration_tests.rs
@@ -182,62 +182,140 @@ mod operators {
 
     #[test]
     fn add() {
-        let input = "5 + 10";
+        ["5 + 10", "5 +10", "5+ 10", "5+10"]
+            .iter()
+            .for_each(|input| {
+                let expected = add_expr(vec![int(5), int(10)]);
+                let actual = parse(input);
 
-        let expected = add_expr(vec![int(5), int(10)]);
-        let actual = parse(input);
-
-        assert_eq!(actual, expected);
+                assert_eq!(actual, expected);
+            });
     }
 
     #[test]
     fn subtract() {
-        let input = "5 - 10";
+        ["5 - 10", "5 -10", "5- 10", "5-10"]
+            .iter()
+            .for_each(|input| {
+                let expected = sub_expr(vec![int(5), int(10)]);
+                let actual = parse(input);
 
-        let expected = sub_expr(vec![int(5), int(10)]);
-        let actual = parse(input);
-
-        assert_eq!(actual, expected);
+                assert_eq!(actual, expected);
+            });
     }
 
     #[test]
     fn multiply() {
-        let input = "5 * 10";
+        ["5 * 10", "5 *10", "5* 10", "5*10"]
+            .iter()
+            .for_each(|input| {
+                let expected = mul_expr(vec![int(5), int(10)]);
+                let actual = parse(input);
 
-        let expected = mul_expr(vec![int(5), int(10)]);
-        let actual = parse(input);
-
-        assert_eq!(actual, expected);
+                assert_eq!(actual, expected);
+            });
     }
 
     #[test]
     fn division() {
-        let input = "5 / 10";
+        ["5 / 10", "5 /10", "5/ 10", "5/10"]
+            .iter()
+            .for_each(|input| {
+                let expected = div_expr(vec![int(5), int(10)]);
+                let actual = parse(input);
 
-        let expected = div_expr(vec![int(5), int(10)]);
-        let actual = parse(input);
-
-        assert_eq!(actual, expected);
+                assert_eq!(actual, expected);
+            });
     }
 
     #[test]
     fn modulo() {
-        let input = "5 % 10";
+        ["5 % 10", "5 %10", "5% 10", "5%10"]
+            .iter()
+            .for_each(|input| {
+                let expected = mod_expr(vec![int(5), int(10)]);
+                let actual = parse(input);
 
-        let expected = mod_expr(vec![int(5), int(10)]);
-        let actual = parse(input);
-
-        assert_eq!(actual, expected);
+                assert_eq!(actual, expected);
+            });
     }
 
     #[test]
     fn power() {
-        let input = "5 ^ 10";
+        ["5 ^ 10", "5 ^10", "5^ 10", "5^10"]
+            .iter()
+            .for_each(|input| {
+                let expected = pow_expr(vec![int(5), int(10)]);
+                let actual = parse(input);
 
-        let expected = pow_expr(vec![int(5), int(10)]);
-        let actual = parse(input);
+                assert_eq!(actual, expected);
+            });
+    }
 
-        assert_eq!(actual, expected);
+    mod operator_and_sign {
+        use super::*;
+
+        #[test]
+        fn all_operators_with_positive_sign() {
+            [
+                ("5++10", add_expr(vec![int(5), int(10)])),
+                ("5-+10", sub_expr(vec![int(5), int(10)])),
+                ("5*+10", mul_expr(vec![int(5), int(10)])),
+                ("5/+10", div_expr(vec![int(5), int(10)])),
+                ("5%+10", mod_expr(vec![int(5), int(10)])),
+                ("5^+10", pow_expr(vec![int(5), int(10)])),
+            ]
+            .into_iter()
+            .for_each(|(input, expected)| {
+                let actual = parse(input);
+                assert_eq!(actual, expected);
+            });
+        }
+
+        #[test]
+        fn all_operators_with_negative_sign() {
+            [
+                ("5+-10", add_expr(vec![int(5), int(-10)])),
+                ("5--10", sub_expr(vec![int(5), int(-10)])),
+                ("5*-10", mul_expr(vec![int(5), int(-10)])),
+                ("5/-10", div_expr(vec![int(5), int(-10)])),
+                ("5%-10", mod_expr(vec![int(5), int(-10)])),
+                ("5^-10", pow_expr(vec![int(5), int(-10)])),
+            ]
+            .into_iter()
+            .for_each(|(input, expected)| {
+                let actual = parse(input);
+                assert_eq!(actual, expected);
+            });
+        }
+
+        #[test]
+        #[should_panic]
+        fn multiply_as_sign() {
+            let input = "5+*10";
+            parse(input);
+        }
+
+        #[test]
+        #[should_panic]
+        fn divide_as_sign() {
+            let input = "5+/10";
+            parse(input);
+        }
+
+        #[test]
+        #[should_panic]
+        fn modulo_as_sign() {
+            let input = "5+%10";
+            parse(input);
+        }
+
+        #[test]
+        #[should_panic]
+        fn power_as_sign() {
+            let input = "5+^10";
+            parse(input);
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!---
If this PR closes an issue, please link it here using the Github Syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5.

# PR description

The previous version of the parser would include `-` in numbers, which meant that `-1` would always be seen as a negative number, even in something like `1-1`. To fix this the parser will no longer look for negative numbers, rather the `-` when specifying a negative number will be parsed into one operator and one negative number and in the subsequent conversion to an expression the decision is made if it should be a subtraction operator or a negative number.

This also patches the internal dependencies to look in the workspace instead of on crates.io, which will need to be undone before publishing new versions.