### PR TITLE
Add basic word boundary handling

### DIFF
--- a/raekna-common/src/lib.rs
+++ b/raekna-common/src/lib.rs
@@ -11,7 +11,7 @@ pub trait RCalculator {
     fn get_selection(&self, selection_start: EditPosition, selection_end: EditPosition) -> String;
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct EditPosition {
     pub line: usize,
     pub column: usize,

--- a/raekna-common/src/lib.rs
+++ b/raekna-common/src/lib.rs
@@ -9,7 +9,11 @@ pub trait RCalculator {
     fn get_line(&self, index: usize) -> CommonResult<(&str, &str)>;
     fn update_line(&mut self, actions: Vec<EditAction>);
     fn get_selection(&self, selection_start: EditPosition, selection_end: EditPosition) -> String;
-    fn get_word_boundaries(&self, origin: EditPosition) -> Option<(EditPosition, EditPosition)>;
+    fn get_word_boundaries(
+        &self,
+        origin: EditPosition,
+        priority: BoundaryPriority,
+    ) -> Option<(EditPosition, EditPosition)>;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -22,6 +26,13 @@ impl EditPosition {
     pub fn new(line: usize, column: usize) -> Self {
         Self { line, column }
     }
+}
+
+#[derive(Copy, Clone)]
+pub enum BoundaryPriority {
+    None,
+    Left,
+    Right,
 }
 
 #[derive(Clone, Debug)]

--- a/raekna-common/src/lib.rs
+++ b/raekna-common/src/lib.rs
@@ -9,6 +9,7 @@ pub trait RCalculator {
     fn get_line(&self, index: usize) -> CommonResult<(&str, &str)>;
     fn update_line(&mut self, actions: Vec<EditAction>);
     fn get_selection(&self, selection_start: EditPosition, selection_end: EditPosition) -> String;
+    fn get_word_boundaries(&self, origin: EditPosition) -> Option<(EditPosition, EditPosition)>;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/raekna-storage/src/edit_handler.rs
+++ b/raekna-storage/src/edit_handler.rs
@@ -87,6 +87,7 @@ impl<'a> EditHandler<'a> {
                 }
             }
             Some(end) => {
+                // TODO: Fix
                 if start.line == end.line {
                     let end_str = self
                         .line_at(start.line, |s| s.to_owned())

--- a/raekna-storage/src/lib.rs
+++ b/raekna-storage/src/lib.rs
@@ -1,3 +1,4 @@
 mod edit_handler;
 mod lines;
 pub mod storage;
+mod word_boundaries;

--- a/raekna-storage/src/storage.rs
+++ b/raekna-storage/src/storage.rs
@@ -73,46 +73,6 @@ impl Storage {
 mod tests {
     use super::*;
 
-    mod test_get_word_boundaries {
-        use super::*;
-
-        #[test]
-        fn origin_line_out_of_bounds() {
-            let lines = Lines {
-                content: vec!["abc".to_owned(), "def".to_owned(), "ghi".to_owned()],
-                results: vec![],
-            };
-            let storage = Storage { lines };
-
-            let origin = EditPosition::new(3, 2);
-            let actual = storage.get_word_boundaries(origin, BoundaryPriority::None);
-
-            assert_eq!(actual, None);
-        }
-
-        #[test]
-        fn normal_usage() {
-            let lines = Lines {
-                content: vec!["abc".to_owned(), "def".to_owned(), "ghi".to_owned()],
-                results: vec![],
-            };
-            let storage = Storage { lines };
-
-            let origin = EditPosition::new(1, 2);
-            let actual = storage.get_word_boundaries(origin, BoundaryPriority::None);
-
-            let expected = (EditPosition::new(1, 0), EditPosition::new(1, 3));
-            let expected = Some(expected);
-
-            assert_eq!(actual, expected);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
     mod test_handle_actions {
         use super::*;
 
@@ -204,6 +164,41 @@ mod tests {
             sut.handle_actions(actions);
 
             assert_eq!(sut.lines.content, vec!["abf".to_owned()]);
+        }
+    }
+
+    mod test_get_word_boundaries {
+        use super::*;
+
+        #[test]
+        fn origin_line_out_of_bounds() {
+            let lines = Lines {
+                content: vec!["abc".to_owned(), "def".to_owned(), "ghi".to_owned()],
+                results: vec![],
+            };
+            let storage = Storage { lines };
+
+            let origin = EditPosition::new(3, 2);
+            let actual = storage.get_word_boundaries(origin, BoundaryPriority::None);
+
+            assert_eq!(actual, None);
+        }
+
+        #[test]
+        fn normal_usage() {
+            let lines = Lines {
+                content: vec!["abc".to_owned(), "def".to_owned(), "ghi".to_owned()],
+                results: vec![],
+            };
+            let storage = Storage { lines };
+
+            let origin = EditPosition::new(1, 2);
+            let actual = storage.get_word_boundaries(origin, BoundaryPriority::None);
+
+            let expected = (EditPosition::new(1, 0), EditPosition::new(1, 3));
+            let expected = Some(expected);
+
+            assert_eq!(actual, expected);
         }
     }
 }

--- a/raekna-storage/src/storage.rs
+++ b/raekna-storage/src/storage.rs
@@ -3,7 +3,7 @@ use raekna_common::{
     EditAction, EditPosition,
 };
 
-use crate::{edit_handler::EditHandler, lines::Lines};
+use crate::{edit_handler::EditHandler, lines::Lines, word_boundaries::find_word_boundaries};
 
 #[derive(Debug, Default)]
 pub struct Storage {
@@ -51,6 +51,59 @@ impl Storage {
             }
             lines.push(&self.lines[selection_end.line][..selection_end.column]);
             lines.join("\n")
+        }
+    }
+
+    pub fn get_word_boundaries(
+        &self,
+        origin: EditPosition,
+    ) -> Option<(EditPosition, EditPosition)> {
+        let EditPosition { line, column } = origin;
+        if line >= self.lines.len() {
+            None
+        } else {
+            find_word_boundaries(&self.lines[line], column)
+                .map(|(start, end)| (EditPosition::new(line, start), EditPosition::new(line, end)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod test_get_word_boundaries {
+        use super::*;
+
+        #[test]
+        fn origin_line_out_of_bounds() {
+            let lines = Lines {
+                content: vec!["abc".to_owned(), "def".to_owned(), "ghi".to_owned()],
+                results: vec![],
+            };
+            let storage = Storage { lines };
+
+            let origin = EditPosition::new(3, 2);
+            let actual = storage.get_word_boundaries(origin);
+
+            assert_eq!(actual, None);
+        }
+
+        #[test]
+        fn normal_usage() {
+            let lines = Lines {
+                content: vec!["abc".to_owned(), "def".to_owned(), "ghi".to_owned()],
+                results: vec![],
+            };
+            let storage = Storage { lines };
+
+            let origin = EditPosition::new(1, 2);
+            let actual = storage.get_word_boundaries(origin);
+
+            let expected = (EditPosition::new(1, 0), EditPosition::new(1, 3));
+            let expected = Some(expected);
+
+            assert_eq!(actual, expected);
         }
     }
 }

--- a/raekna-storage/src/storage.rs
+++ b/raekna-storage/src/storage.rs
@@ -1,6 +1,6 @@
 use raekna_common::{
     errors::{CommonError, CommonResult},
-    EditAction, EditPosition,
+    BoundaryPriority, EditAction, EditPosition,
 };
 
 use crate::{edit_handler::EditHandler, lines::Lines, word_boundaries::find_word_boundaries};
@@ -57,12 +57,13 @@ impl Storage {
     pub fn get_word_boundaries(
         &self,
         origin: EditPosition,
+        priority: BoundaryPriority,
     ) -> Option<(EditPosition, EditPosition)> {
         let EditPosition { line, column } = origin;
         if line >= self.lines.len() {
             None
         } else {
-            find_word_boundaries(&self.lines[line], column)
+            find_word_boundaries(&self.lines[line], column, priority)
                 .map(|(start, end)| (EditPosition::new(line, start), EditPosition::new(line, end)))
         }
     }
@@ -84,7 +85,7 @@ mod tests {
             let storage = Storage { lines };
 
             let origin = EditPosition::new(3, 2);
-            let actual = storage.get_word_boundaries(origin);
+            let actual = storage.get_word_boundaries(origin, BoundaryPriority::None);
 
             assert_eq!(actual, None);
         }
@@ -98,7 +99,7 @@ mod tests {
             let storage = Storage { lines };
 
             let origin = EditPosition::new(1, 2);
-            let actual = storage.get_word_boundaries(origin);
+            let actual = storage.get_word_boundaries(origin, BoundaryPriority::None);
 
             let expected = (EditPosition::new(1, 0), EditPosition::new(1, 3));
             let expected = Some(expected);

--- a/raekna-storage/src/word_boundaries.rs
+++ b/raekna-storage/src/word_boundaries.rs
@@ -111,7 +111,7 @@ impl Sequences {
 
     pub fn increment(&mut self, ctype: SequenceType, index: usize) {
         let last_seq_index = self.seq.len().saturating_sub(1);
-        if self.seq.len() > 0 && ctype == self.seq[last_seq_index].seq_type {
+        if !self.seq.is_empty() && ctype == self.seq[last_seq_index].seq_type {
             let mut sequence = &mut self.seq[last_seq_index];
             sequence.end += 1
         } else {

--- a/raekna-storage/src/word_boundaries.rs
+++ b/raekna-storage/src/word_boundaries.rs
@@ -1,0 +1,224 @@
+/// Returns the indices of the word boundaries from an origin point.
+///
+/// There are three classes of characters that create words when the appear in sequence:
+/// 1. Alphanumeric and underscores
+/// 2. Whitespace
+/// 3. Everything else
+///
+/// If the origin is on the border between two words the above numbering shows the priority of different types of words.
+///
+/// The following string, for example, contains four separate words:
+/// `abc   ,.-de_f`
+///
+/// This function does no specific handling of newlines since for the use case strings cannot have newlines.
+pub fn find_word_boundaries(input: &str, origin: usize) -> Option<(usize, usize)> {
+    if input.is_empty() || origin > input.len() {
+        return None;
+    }
+    let sequences = generate_sequences(input);
+    find_sequence(&sequences, origin).map(CharSequence::boundaries)
+}
+
+fn generate_sequences(input: &str) -> Vec<CharSequence> {
+    let mut sequences = Sequences::new();
+    input.chars().into_iter().enumerate().for_each(|(i, c)| {
+        let ctype = if c.is_alphanumeric() || c == '_' {
+            SequenceType::Word
+        } else if c.is_whitespace() {
+            SequenceType::Whitespace
+        } else {
+            SequenceType::Other
+        };
+        sequences.increment(ctype, i);
+    });
+    sequences.finish()
+}
+
+fn find_sequence(sequences: &[CharSequence], origin: usize) -> Option<CharSequence> {
+    let mut seq = None;
+    for cs in sequences.iter() {
+        if cs.start > origin {
+            break;
+        } else if cs.start <= origin && cs.end >= origin {
+            match (cs.seq_type, seq.map(|cs: CharSequence| cs.seq_type)) {
+                (SequenceType::Word, Some(SequenceType::Whitespace | SequenceType::Other))
+                | (SequenceType::Whitespace, Some(SequenceType::Other))
+                | (_, None) => {
+                    seq = Some(*cs);
+                }
+                _ => {}
+            }
+        }
+    }
+    seq
+}
+
+#[derive(Copy, Clone)]
+struct CharSequence {
+    seq_type: SequenceType,
+    start: usize,
+    end: usize,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum SequenceType {
+    Word,
+    Whitespace,
+    Other,
+}
+
+impl CharSequence {
+    fn boundaries(self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+}
+
+#[derive(Default)]
+struct Sequences {
+    seq: Vec<CharSequence>,
+}
+
+impl Sequences {
+    pub fn new() -> Self {
+        Self {
+            seq: Vec::with_capacity(1),
+        }
+    }
+
+    pub fn increment(&mut self, ctype: SequenceType, index: usize) {
+        let last_seq_index = self.seq.len().saturating_sub(1);
+        if self.seq.len() > 0 && ctype == self.seq[last_seq_index].seq_type {
+            let mut sequence = &mut self.seq[last_seq_index];
+            sequence.end += 1
+        } else {
+            let new_sequence = CharSequence {
+                seq_type: ctype,
+                start: index,
+                end: index + 1,
+            };
+            self.seq.push(new_sequence)
+        }
+    }
+
+    pub fn finish(self) -> Vec<CharSequence> {
+        self.seq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_input() {
+        let actual = find_word_boundaries("", 0);
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_origin_out_of_bounds() {
+        let actual = find_word_boundaries("abc", 4);
+        assert_eq!(actual, None);
+    }
+
+    mod test_single_word {
+        use super::*;
+
+        #[test]
+        fn test_origin_at_start() {
+            ["abc", "   ", "..."].iter().for_each(|input| {
+                let actual = find_word_boundaries(input, 0);
+                let expected = Some((0, 3));
+                assert_eq!(actual, expected);
+            });
+        }
+
+        #[test]
+        fn test_origin_at_end() {
+            ["abc", "   ", "..."].iter().for_each(|input| {
+                let actual = find_word_boundaries(input, 3);
+                let expected = Some((0, 3));
+                assert_eq!(actual, expected);
+            });
+        }
+
+        #[test]
+        fn test_origin_inside() {
+            ["abc", "   ", "..."].iter().for_each(|input| {
+                let actual = find_word_boundaries(input, 2);
+                let expected = Some((0, 3));
+                assert_eq!(actual, expected);
+            });
+        }
+    }
+
+    mod test_multiple_words {
+        use super::*;
+
+        #[test]
+        fn test_origin_at_start() {
+            let actual = find_word_boundaries("abcdef   ...", 0);
+            let expected = Some((0, 6));
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_origin_at_end() {
+            let actual = find_word_boundaries("abcd     ,...", 13);
+            let expected = Some((9, 13));
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_origin_inside() {
+            let actual = find_word_boundaries("abcde   ,..", 2);
+            let expected = Some((0, 5));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("abcde   ,..", 6);
+            let expected = Some((5, 8));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("abcde   ,..", 10);
+            let expected = Some((8, 11));
+            assert_eq!(actual, expected);
+        }
+    }
+
+    mod test_precedence_rules {
+        use super::*;
+
+        #[test]
+        fn test_word_and_whitespace() {
+            let actual = find_word_boundaries("abc   def", 3);
+            let expected = Some((0, 3));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("abc   def", 6);
+            let expected = Some((6, 9));
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_word_and_other() {
+            let actual = find_word_boundaries("abc...def", 3);
+            let expected = Some((0, 3));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("abc...def", 6);
+            let expected = Some((6, 9));
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_whitespace_and_other() {
+            let actual = find_word_boundaries("   ...   ", 3);
+            let expected = Some((0, 3));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("   ...   ", 6);
+            let expected = Some((6, 9));
+            assert_eq!(actual, expected);
+        }
+    }
+}

--- a/raekna-ui/src/coordinator/input_handler/keyboard_edit_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/keyboard_edit_handler.rs
@@ -157,15 +157,21 @@ impl KeyboardEditHandler {
                         }
                     }
                 };
-
                 let before = widths_before.len();
                 Self::maybe_hide_selection(content, selection_start.line, selection_start.column);
                 Self::perform_action(content, actions, dimensions);
                 let after = content.text_buffer.line_widths().len();
                 if selection_end.is_none() && before == after {
-                    content
-                        .caret_position
-                        .move_left(content.text_buffer.line_widths());
+                    if active_modifiers.ctrl {
+                        let line = content.caret_position.line;
+                        content
+                            .caret_position
+                            .set_position(line, potential_column_after);
+                    } else {
+                        content
+                            .caret_position
+                            .move_left(content.text_buffer.line_widths());
+                    }
                 } else if selection_end.is_none() {
                     let line = content.caret_position.line;
                     content

--- a/raekna-ui/src/coordinator/input_handler/keyboard_edit_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/keyboard_edit_handler.rs
@@ -3,7 +3,10 @@ use raekna_common::{EditAction, EditPosition};
 
 use crate::{
     constants::TEXT_PADDING,
-    coordinator::{content::Content, dimensions::Dimensions, user_input::KeyboardEdit},
+    coordinator::{
+        active_modifiers::ActiveModifiers, content::Content, dimensions::Dimensions,
+        user_input::KeyboardEdit,
+    },
 };
 
 #[derive(Debug, Default)]
@@ -14,6 +17,7 @@ impl KeyboardEditHandler {
         &self,
         content: &mut Content,
         dimensions: &mut Dimensions,
+        active_modifiers: ActiveModifiers,
         edit: KeyboardEdit,
     ) {
         let (selection_start, selection_end) = content.get_edit_selection();
@@ -78,22 +82,41 @@ impl KeyboardEditHandler {
                     Self::delete_selection(content, dimensions, selection_start, selection_end);
                 }
                 None => {
-                    let actions = vec![EditAction::DeleteForward(selection_start)];
-                    Self::maybe_hide_selection(
-                        content,
-                        selection_start.line,
-                        selection_start.column,
-                    );
-                    Self::perform_action(content, actions, dimensions);
+                    if active_modifiers.ctrl {
+                        match content.calculator.get_word_boundaries(
+                            selection_start,
+                            raekna_common::BoundaryPriority::Right,
+                        ) {
+                            Some((_, boundary)) => Self::delete_selection(
+                                content,
+                                dimensions,
+                                selection_start,
+                                boundary,
+                            ),
+                            None => {
+                                let actions = vec![EditAction::DeleteForward(selection_start)];
+                                Self::maybe_hide_selection(
+                                    content,
+                                    selection_start.line,
+                                    selection_start.column,
+                                );
+                                Self::perform_action(content, actions, dimensions);
+                            }
+                        }
+                    } else {
+                        let actions = vec![EditAction::DeleteForward(selection_start)];
+                        Self::maybe_hide_selection(
+                            content,
+                            selection_start.line,
+                            selection_start.column,
+                        );
+                        Self::perform_action(content, actions, dimensions);
+                    }
                 }
             },
             KeyboardEdit::Backspace => {
-                let actions = vec![EditAction::Delete {
-                    selection_start,
-                    selection_end,
-                }];
                 let widths_before = content.text_buffer.line_widths();
-                let potential_column_after = {
+                let mut potential_column_after = {
                     let line = content.caret_position.line;
                     if line > 0 {
                         widths_before[line - 1]
@@ -101,6 +124,40 @@ impl KeyboardEditHandler {
                         widths_before[line]
                     }
                 };
+                let actions = match selection_end {
+                    Some(selection_end) => {
+                        vec![EditAction::Delete {
+                            selection_start,
+                            selection_end: Some(selection_end),
+                        }]
+                    }
+                    None => {
+                        if active_modifiers.ctrl {
+                            match content.calculator.get_word_boundaries(
+                                selection_start,
+                                raekna_common::BoundaryPriority::Left,
+                            ) {
+                                Some((boundary, _)) => {
+                                    potential_column_after = boundary.column;
+                                    vec![EditAction::Delete {
+                                        selection_start: boundary,
+                                        selection_end: Some(selection_start),
+                                    }]
+                                }
+                                None => vec![EditAction::Delete {
+                                    selection_start,
+                                    selection_end,
+                                }],
+                            }
+                        } else {
+                            vec![EditAction::Delete {
+                                selection_start,
+                                selection_end,
+                            }]
+                        }
+                    }
+                };
+
                 let before = widths_before.len();
                 Self::maybe_hide_selection(content, selection_start.line, selection_start.column);
                 Self::perform_action(content, actions, dimensions);

--- a/raekna-ui/src/coordinator/input_handler/keyboard_movement_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/keyboard_movement_handler.rs
@@ -44,21 +44,75 @@ impl KeyboardMovementHandler {
             KeyboardMovement::Left => match content.root_position {
                 Some(root) if !active_modifiers.shift => {
                     let (start, _) = get_ordered_selection(root, content.caret_position);
-                    content
-                        .caret_position
-                        .set_position(start.line, start.column);
+                    if active_modifiers.ctrl {
+                        match content
+                            .calculator
+                            .get_word_boundaries(content.caret_position.into())
+                        {
+                            Some((boundary, _)) => content
+                                .caret_position
+                                .set_position(boundary.line, boundary.column),
+                            None => content
+                                .caret_position
+                                .set_position(start.line, start.column),
+                        }
+                    } else {
+                        content
+                            .caret_position
+                            .set_position(start.line, start.column);
+                    }
                 }
                 _ => {
-                    content.caret_position.move_left(line_widths);
+                    if active_modifiers.ctrl {
+                        match content
+                            .calculator
+                            .get_word_boundaries(content.caret_position.into())
+                        {
+                            Some((boundary, _)) => content
+                                .caret_position
+                                .set_position(boundary.line, boundary.column),
+                            None => {
+                                content.caret_position.move_left(line_widths);
+                            }
+                        }
+                    } else {
+                        content.caret_position.move_left(line_widths);
+                    }
                 }
             },
             KeyboardMovement::Right => match content.root_position {
                 Some(root) if !active_modifiers.shift => {
                     let (_, end) = get_ordered_selection(root, content.caret_position);
-                    content.caret_position.set_position(end.line, end.column);
+                    if active_modifiers.ctrl {
+                        match content
+                            .calculator
+                            .get_word_boundaries(content.caret_position.into())
+                        {
+                            Some((_, boundary)) => content
+                                .caret_position
+                                .set_position(boundary.line, boundary.column),
+                            None => content.caret_position.set_position(end.line, end.column),
+                        }
+                    } else {
+                        content.caret_position.set_position(end.line, end.column);
+                    }
                 }
                 _ => {
-                    content.caret_position.move_right(line_widths);
+                    if active_modifiers.ctrl {
+                        match content
+                            .calculator
+                            .get_word_boundaries(content.caret_position.into())
+                        {
+                            Some((_, boundary)) => content
+                                .caret_position
+                                .set_position(boundary.line, boundary.column),
+                            None => {
+                                content.caret_position.move_right(line_widths);
+                            }
+                        }
+                    } else {
+                        content.caret_position.move_right(line_widths);
+                    }
                 }
             },
             KeyboardMovement::Home => {

--- a/raekna-ui/src/coordinator/input_handler/keyboard_movement_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/keyboard_movement_handler.rs
@@ -62,10 +62,18 @@ impl KeyboardMovementHandler {
                 }
             },
             KeyboardMovement::Home => {
-                content.caret_position.home();
+                if active_modifiers.ctrl {
+                    content.caret_position.page_up();
+                } else {
+                    content.caret_position.home();
+                }
             }
             KeyboardMovement::End => {
-                content.caret_position.end(line_widths);
+                if active_modifiers.ctrl {
+                    content.caret_position.page_down(line_widths);
+                } else {
+                    content.caret_position.end(line_widths);
+                }
             }
             KeyboardMovement::PageUp => {
                 content.caret_position.page_up();

--- a/raekna-ui/src/coordinator/input_handler/keyboard_movement_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/keyboard_movement_handler.rs
@@ -1,3 +1,5 @@
+use raekna_common::BoundaryPriority;
+
 use crate::{
     coordinator::{
         active_modifiers::ActiveModifiers, content::Content, dimensions::Dimensions,
@@ -45,10 +47,10 @@ impl KeyboardMovementHandler {
                 Some(root) if !active_modifiers.shift => {
                     let (start, _) = get_ordered_selection(root, content.caret_position);
                     if active_modifiers.ctrl {
-                        match content
-                            .calculator
-                            .get_word_boundaries(content.caret_position.into())
-                        {
+                        match content.calculator.get_word_boundaries(
+                            content.caret_position.into(),
+                            BoundaryPriority::Left,
+                        ) {
                             Some((boundary, _)) => content
                                 .caret_position
                                 .set_position(boundary.line, boundary.column),
@@ -64,10 +66,10 @@ impl KeyboardMovementHandler {
                 }
                 _ => {
                     if active_modifiers.ctrl {
-                        match content
-                            .calculator
-                            .get_word_boundaries(content.caret_position.into())
-                        {
+                        match content.calculator.get_word_boundaries(
+                            content.caret_position.into(),
+                            BoundaryPriority::Left,
+                        ) {
                             Some((boundary, _)) => content
                                 .caret_position
                                 .set_position(boundary.line, boundary.column),
@@ -84,10 +86,10 @@ impl KeyboardMovementHandler {
                 Some(root) if !active_modifiers.shift => {
                     let (_, end) = get_ordered_selection(root, content.caret_position);
                     if active_modifiers.ctrl {
-                        match content
-                            .calculator
-                            .get_word_boundaries(content.caret_position.into())
-                        {
+                        match content.calculator.get_word_boundaries(
+                            content.caret_position.into(),
+                            BoundaryPriority::Right,
+                        ) {
                             Some((_, boundary)) => content
                                 .caret_position
                                 .set_position(boundary.line, boundary.column),
@@ -99,10 +101,10 @@ impl KeyboardMovementHandler {
                 }
                 _ => {
                     if active_modifiers.ctrl {
-                        match content
-                            .calculator
-                            .get_word_boundaries(content.caret_position.into())
-                        {
+                        match content.calculator.get_word_boundaries(
+                            content.caret_position.into(),
+                            BoundaryPriority::Right,
+                        ) {
                             Some((_, boundary)) => content
                                 .caret_position
                                 .set_position(boundary.line, boundary.column),

--- a/raekna-ui/src/coordinator/input_handler/mod.rs
+++ b/raekna-ui/src/coordinator/input_handler/mod.rs
@@ -45,8 +45,12 @@ impl InputHandler {
             }
             UserInput::KeyboardEdit(edit) => {
                 content.controls.set_caret_visible();
-                self.keyboard_edit_handler
-                    .on_keyboard_edit(content, dimensions, edit)
+                self.keyboard_edit_handler.on_keyboard_edit(
+                    content,
+                    dimensions,
+                    self.active_modifiers,
+                    edit,
+                )
             }
             UserInput::MouseInput(input) => {
                 if let MouseInput::MouseClick { .. } = input {

--- a/raekna-ui/src/coordinator/input_handler/mouse_input_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/mouse_input_handler.rs
@@ -1,3 +1,4 @@
+use raekna_common::EditPosition;
 use winit::{
     dpi::PhysicalPosition,
     event::{ElementState, MouseButton},
@@ -218,7 +219,39 @@ impl MouseInputHandler {
                             };
                             self.set_selection(self.selection.0, selection_end);
                         } else if click_count == 2 {
-                            // select word
+                            let clicked_position = self.get_line_and_column(dimensions);
+                            let clicked_position =
+                                EditPosition::new(clicked_position.line, clicked_position.column);
+                            let word_boundaries =
+                                content.calculator.get_word_boundaries(clicked_position);
+                            match word_boundaries {
+                                Some((boundary_start, boundary_end)) => {
+                                    if active_modifiers.shift {
+                                        todo!()
+                                    } else {
+                                        self.selection.0 = CaretPosition {
+                                            line: boundary_start.line,
+                                            column: boundary_start.column,
+                                            actual_column: boundary_start.column,
+                                        };
+                                        self.selection.1 = Some(CaretPosition {
+                                            line: boundary_end.line,
+                                            column: boundary_end.column,
+                                            actual_column: boundary_end.column,
+                                        });
+                                    }
+                                }
+                                None => {
+                                    self.mouse_click_position =
+                                        self.get_line_and_column(dimensions);
+                                    let mut clicked_position = self.mouse_click_position;
+                                    self.normalize_caret_position(
+                                        &mut clicked_position,
+                                        line_widths,
+                                    );
+                                    self.selection = (clicked_position, None);
+                                }
+                            }
                         } else if active_modifiers.shift {
                             self.mouse_click_position = content.caret_position;
                             let mut clicked_position = self.get_line_and_column(dimensions);

--- a/raekna-ui/src/coordinator/input_handler/mouse_input_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/mouse_input_handler.rs
@@ -229,16 +229,8 @@ impl MouseInputHandler {
                                     if active_modifiers.shift {
                                         todo!()
                                     } else {
-                                        self.selection.0 = CaretPosition {
-                                            line: boundary_start.line,
-                                            column: boundary_start.column,
-                                            actual_column: boundary_start.column,
-                                        };
-                                        self.selection.1 = Some(CaretPosition {
-                                            line: boundary_end.line,
-                                            column: boundary_end.column,
-                                            actual_column: boundary_end.column,
-                                        });
+                                        self.selection.0 = boundary_start.into();
+                                        self.selection.1 = Some(boundary_end.into());
                                     }
                                 }
                                 None => {

--- a/raekna-ui/src/coordinator/input_handler/mouse_input_handler.rs
+++ b/raekna-ui/src/coordinator/input_handler/mouse_input_handler.rs
@@ -1,4 +1,4 @@
-use raekna_common::EditPosition;
+use raekna_common::{BoundaryPriority, EditPosition};
 use winit::{
     dpi::PhysicalPosition,
     event::{ElementState, MouseButton},
@@ -222,8 +222,9 @@ impl MouseInputHandler {
                             let clicked_position = self.get_line_and_column(dimensions);
                             let clicked_position =
                                 EditPosition::new(clicked_position.line, clicked_position.column);
-                            let word_boundaries =
-                                content.calculator.get_word_boundaries(clicked_position);
+                            let word_boundaries = content
+                                .calculator
+                                .get_word_boundaries(clicked_position, BoundaryPriority::None);
                             match word_boundaries {
                                 Some((boundary_start, boundary_end)) => {
                                     if active_modifiers.shift {

--- a/raekna-ui/src/graphics/controls/caret_position.rs
+++ b/raekna-ui/src/graphics/controls/caret_position.rs
@@ -1,3 +1,5 @@
+use raekna_common::EditPosition;
+
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct CaretPosition {
     pub line: usize,
@@ -135,6 +137,25 @@ impl CaretPosition {
             self.column = line_widths[self.line];
             self.actual_column = self.column;
             true
+        }
+    }
+}
+
+impl From<CaretPosition> for EditPosition {
+    fn from(cp: CaretPosition) -> Self {
+        Self {
+            line: cp.line,
+            column: cp.column,
+        }
+    }
+}
+
+impl From<EditPosition> for CaretPosition {
+    fn from(ep: EditPosition) -> Self {
+        Self {
+            line: ep.line,
+            column: ep.column,
+            actual_column: ep.column,
         }
     }
 }

--- a/raekna-ui/src/graphics/shaders/shader.wgsl
+++ b/raekna-ui/src/graphics/shaders/shader.wgsl
@@ -1,16 +1,16 @@
 // Vertex shader
 
 struct VertexInput {
-    [[location(0)]] position: vec3<f32>;
-    [[location(1)]] color: vec3<f32>;
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec3<f32>,
 };
 
 struct VertexOutput {
-    [[builtin(position)]] clip_position: vec4<f32>;
-    [[location(0)]] color: vec3<f32>;
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec3<f32>,
 };
 
-[[stage(vertex)]]
+@vertex
 fn vs_main(
     model: VertexInput,
 ) -> VertexOutput {
@@ -22,7 +22,7 @@ fn vs_main(
 
 // Fragment shader
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     return vec4<f32>(in.color, 1.0);
 }

--- a/raekna/src/calculator.rs
+++ b/raekna/src/calculator.rs
@@ -37,4 +37,8 @@ impl RCalculator for Calculator {
     fn get_selection(&self, selection_start: EditPosition, selection_end: EditPosition) -> String {
         self.storage.get_selection(selection_start, selection_end)
     }
+
+    fn get_word_boundaries(&self, origin: EditPosition) -> Option<(EditPosition, EditPosition)> {
+        self.storage.get_word_boundaries(origin)
+    }
 }

--- a/raekna/src/calculator.rs
+++ b/raekna/src/calculator.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use raekna_common::{errors::CommonResult, EditAction, EditPosition, RCalculator};
+use raekna_common::{
+    errors::CommonResult, BoundaryPriority, EditAction, EditPosition, RCalculator,
+};
 use raekna_compute::evaluate;
 use raekna_parser::parse;
 use raekna_storage::storage::Storage;
@@ -38,7 +40,11 @@ impl RCalculator for Calculator {
         self.storage.get_selection(selection_start, selection_end)
     }
 
-    fn get_word_boundaries(&self, origin: EditPosition) -> Option<(EditPosition, EditPosition)> {
-        self.storage.get_word_boundaries(origin)
+    fn get_word_boundaries(
+        &self,
+        origin: EditPosition,
+        priority: BoundaryPriority,
+    ) -> Option<(EditPosition, EditPosition)> {
+        self.storage.get_word_boundaries(origin, priority)
     }
 }


### PR DESCRIPTION
# PR description

This PR adds initial word boundary handling through double clicking with the mouse and ctrl+left/right arrow keys.

# Are there any follow-ups?

Double clicking with the mouse works in the basic case of selecting the word you click on but has a couple of things that need to be improved:
- If you double click to select a word and then adjust the selection either by shift+click or shift+arrows/home/end/etc, the selection should always grow, not shrink
- If you shift+double click the selection should be from the previous caret position to the far boundary of the double clicked word. This currently doesn't work

Ctrl+left/right arrows also generally works but has one piece of functionality that is missing:
- For a string like `abc def`, if the caret is to the right of the `c` and you click ctrl+right arrow the caret should move to the right of the `f`. It should skip char sequences that are only one character if they are lower priority than the sequence that comes after it