### PR TITLE
Improve ctrl+right/left arrows

### DIFF
--- a/raekna-common/src/lib.rs
+++ b/raekna-common/src/lib.rs
@@ -28,7 +28,7 @@ impl EditPosition {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum BoundaryPriority {
     None,
     Left,

--- a/raekna-storage/src/word_boundaries.rs
+++ b/raekna-storage/src/word_boundaries.rs
@@ -265,6 +265,21 @@ mod tests {
         }
 
         #[test]
+        fn test_left_priority_skips_short_low_prio_sequences() {
+            let actual = find_word_boundaries("abc ", 4, BoundaryPriority::Left);
+            let expected = Some((0, 4));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("abc.", 4, BoundaryPriority::Left);
+            let expected = Some((0, 4));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries("   .", 4, BoundaryPriority::Left);
+            let expected = Some((0, 4));
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
         fn test_right_priority() {
             let actual = find_word_boundaries("abc   ", 3, BoundaryPriority::Right);
             let expected = Some((3, 6));
@@ -276,6 +291,21 @@ mod tests {
 
             let actual = find_word_boundaries("   ...", 3, BoundaryPriority::Right);
             let expected = Some((3, 6));
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_right_priority_skips_short_low_prio_sequences() {
+            let actual = find_word_boundaries(" abc", 0, BoundaryPriority::Right);
+            let expected = Some((0, 4));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries(".abc", 0, BoundaryPriority::Right);
+            let expected = Some((0, 4));
+            assert_eq!(actual, expected);
+
+            let actual = find_word_boundaries(".   ", 0, BoundaryPriority::Right);
+            let expected = Some((0, 4));
             assert_eq!(actual, expected);
         }
     }


### PR DESCRIPTION
# PR description

This PR is part of a set of work adding user interaction while holding the ctrl key. This PR improves ctrl + left and right arrow keys. For the following string `abc def`, if the caret start on column 0 and you ctrl+right arrow to go to the left arrow the caret would previously move `0-3-4-6` but now it moves `0-3-6`, that is, it skips one character sequences if the sequences that follow are higher priority.

# Are there any follow-ups?

After this PR remains one chunk of work for the interaction with ctrl, as mentioned in the original PR:

Double clicking with the mouse works in the basic case of selecting the word you click on but has a couple of things that need to be improved:

If you double click to select a word and then adjust the selection either by shift+click or shift+arrows/home/end/etc, the selection should always grow, not shrink
If you shift+double click the selection should be from the previous caret position to the far boundary of the double clicked word. This currently doesn't work