### PR TITLE
Don't show terminal window when running in release mode on Windows

### DIFF
--- a/raekna/src/main.rs
+++ b/raekna/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use raekna_ui::show_ui;
 
 mod calculator;


### PR DESCRIPTION
# PR description

Previously you would always get a terminal window when running the application. With this PR you will no longer get that terminal window in release mode.